### PR TITLE
tasks.json file for VS Code

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,40 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Simulate",
+            "type": "shell",
+            "command": "${workspaceFolder}\\..\\bin\\sim.bat ${input:sv-module} ${fileBasename} ${input:sv-files}",
+            "options": {
+                "cwd": "${fileDirname}"
+            },
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "Synthesize",
+            "type": "shell",
+            "command": "${workspaceFolder}\\..\\bin\\synth.bat ${input:sv-module} ${fileBasename} ${input:sv-files}",
+            "options": {
+                "cwd": "${fileDirname}"
+            },
+            "group": "build",
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "id": "sv-module",
+            "type": "promptString",
+            "description": "A SystemVerilog module"
+        },
+        {
+            "id": "sv-files",
+            "type": "promptString",
+            "description": "Additional SystemVerilog files",
+            "default": ""
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a `tasks.json` file which can be used with VS Code to simulate and synthesize your SystemVerilog code.

TO DO:
- [ ] Add support for other systems than Windows
- [ ] Add documentation how to use this file

Documentation for the `tasks.json` file: [Tasks in VS Code](https://code.visualstudio.com/docs/editor/tasks)